### PR TITLE
Implement manual playback for audio responses

### DIFF
--- a/src/lib/components/Ask.svelte
+++ b/src/lib/components/Ask.svelte
@@ -14,6 +14,8 @@
 			role: 'assistant' | 'user';
 			text: string;
 			image?: string;
+			audio?: string;
+			audioLoading?: boolean;
 		}[];
 	} = $props();
 
@@ -59,6 +61,11 @@
 				behavior: 'smooth'
 			});
 		}
+	}
+
+	function playAudio(url: string) {
+		const audio = new Audio(url);
+		audio.play();
 	}
 
 	function renderMarkdown(text: string) {
@@ -107,6 +114,41 @@
 					<!-- Render markdown content -->
 					{#if conversation.image}
 						<img src={conversation.image} alt="Response" class="mt-2 rounded-lg" />
+					{/if}
+					{#if conversation.audioLoading}
+						<button disabled class="mt-2 flex items-center text-gray-400">
+							<svg class="mr-1 h-4 w-4 animate-spin" viewBox="0 0 24 24">
+								<circle
+									class="opacity-25"
+									cx="12"
+									cy="12"
+									r="10"
+									stroke="currentColor"
+									stroke-width="4"
+									fill="none"
+								/>
+								<path
+									class="opacity-75"
+									fill="currentColor"
+									d="M4 12a8 8 0 018-8v4l3-3-3-3v4a12 12 0 00-12 12h4z"
+								/>
+							</svg>
+							Generating audio...
+						</button>
+					{:else if conversation.audio}
+						<button
+							class="mt-2 text-gray-400 hover:text-white"
+							onclick={() => playAudio(conversation.audio!)}
+						>
+							<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+									d="M9 19V6l-2 2H5v8h2l2 2zM13 5l7 7-7 7V5z"
+								/>
+							</svg>
+						</button>
 					{/if}
 				</div>
 			{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,6 +10,8 @@
 		role: 'assistant' | 'user';
 		text: string;
 		image?: string;
+		audio?: string;
+		audioLoading?: boolean;
 	}[] = $state([]);
 
 	let askComponent: Ask | null = $state(null);
@@ -52,7 +54,7 @@
 		conversations = [
 			...conversations,
 			{ role: 'user', text: question },
-			{ role: 'assistant', text: '' }
+			{ role: 'assistant', text: '', audioLoading: false }
 		];
 
 		try {
@@ -81,9 +83,17 @@
 						i === conversations.length - 1 ? { ...conv, image: imageUrl } : conv
 					);
 				},
+				done() {
+					conversations = conversations.map((conv, i) =>
+						i === conversations.length - 1 ? { ...conv, audioLoading: true } : conv
+					);
+				},
 				audio(audioUrl) {
-					const audio = new Audio(audioUrl);
-					audio.play();
+					conversations = conversations.map((conv, i) =>
+						i === conversations.length - 1
+							? { ...conv, audio: audioUrl, audioLoading: false }
+							: conv
+					);
 				}
 			});
 			await updateQueue.wait();


### PR DESCRIPTION
## Summary
- store audio URLs in conversations and mark loading state
- add speaker button for manual audio playback
- handle audio done event with loading spinner

## Testing
- `npm run lint`
- `npm run test:unit`
